### PR TITLE
Updates to RFC 4210 and RFC 4211

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,11 @@ Revision 0.4.0, released 10-07-2021
 -----------------------------------
 - Added opentypemap to manage the open type maps for all modules
 - Add RFC9092 providing CMS Content Type for Geofeed Data
+- Update RFC4210 by Russ Housley to import from RFC 5280, RFC 4211, and
+  RFC6402 instead of earlier RFCs covering the same things
+- Update RFC4210 o import from RFC 5280 and RFC5252 instead of earlier
+  RFCs covering the same things, and to include an opentype map for
+  AttributeTypeAndValue
 
 Revision 0.3.2, released 14-06-2021
 -----------------------------------

--- a/pyasn1_alt_modules/rfc4210.py
+++ b/pyasn1_alt_modules/rfc4210.py
@@ -9,6 +9,8 @@
 #
 # Based on Alex Railean's work
 # Modified by Russ Housley to import from RFC 5280 instead of RFC 2459.
+# Modified by Russ Housley to import from RFC 4211 instead of RFC 2511.
+# Modified by Russ Housley to import from RFC 6402 instead of RFC 2314.
 #
 from pyasn1.type import char
 from pyasn1.type import constraint
@@ -18,8 +20,8 @@ from pyasn1.type import tag
 from pyasn1.type import univ
 from pyasn1.type import useful
 
-from pyasn1_alt_modules import rfc2314
-from pyasn1_alt_modules import rfc2511
+from pyasn1_alt_modules import rfc6402
+from pyasn1_alt_modules import rfc4211
 from pyasn1_alt_modules import rfc5280
 
 MAX = float('inf')
@@ -135,7 +137,7 @@ class RevDetails(univ.Sequence):
      }
     """
     componentType = namedtype.NamedTypes(
-        namedtype.NamedType('certDetails', rfc2511.CertTemplate()),
+        namedtype.NamedType('certDetails', rfc4211.CertTemplate()),
         namedtype.OptionalNamedType('crlEntryDetails', rfc5280.Extensions())
     )
 
@@ -153,7 +155,7 @@ class CertOrEncCert(univ.Choice):
     """
     componentType = namedtype.NamedTypes(
         namedtype.NamedType('certificate', CMPCertificate().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0))),
-        namedtype.NamedType('encryptedCert', rfc2511.EncryptedValue().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1)))
+        namedtype.NamedType('encryptedCert', rfc4211.EncryptedValue().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1)))
     )
 
 
@@ -167,8 +169,8 @@ class CertifiedKeyPair(univ.Sequence):
     """
     componentType = namedtype.NamedTypes(
         namedtype.NamedType('certOrEncCert', CertOrEncCert()),
-        namedtype.OptionalNamedType('privateKey', rfc2511.EncryptedValue().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0))),
-        namedtype.OptionalNamedType('publicationInfo', rfc2511.PKIPublicationInfo().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1)))
+        namedtype.OptionalNamedType('privateKey', rfc4211.EncryptedValue().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0))),
+        namedtype.OptionalNamedType('publicationInfo', rfc4211.PKIPublicationInfo().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1)))
     )
 
 
@@ -339,7 +341,7 @@ class RevAnnContent(univ.Sequence):
     """
     componentType = namedtype.NamedTypes(
         namedtype.NamedType('status', PKIStatus()),
-        namedtype.NamedType('certId', rfc2511.CertId()),
+        namedtype.NamedType('certId', rfc4211.CertId()),
         namedtype.NamedType('willBeRevokedAt', useful.GeneralizedTime()),
         namedtype.NamedType('badSinceDate', useful.GeneralizedTime()),
         namedtype.OptionalNamedType('crlDetails', rfc5280.Extensions())
@@ -363,7 +365,7 @@ class RevRepContent(univ.Sequence):
             )
         ),
         namedtype.OptionalNamedType(
-            'revCerts', univ.SequenceOf(componentType=rfc2511.CertId()).subtype(
+            'revCerts', univ.SequenceOf(componentType=rfc4211.CertId()).subtype(
                 sizeSpec=constraint.ValueSizeConstraint(1, MAX),
                 explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0)
             )
@@ -461,7 +463,7 @@ class OOBCertHash(univ.Sequence):
             'hashAlg', rfc5280.AlgorithmIdentifier().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0))
         ),
         namedtype.OptionalNamedType(
-            'certId', rfc2511.CertId().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1))
+            'certId', rfc4211.CertId().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1))
         ),
         namedtype.NamedType('hashVal', univ.BitString())
     )
@@ -560,7 +562,7 @@ class PKIBody(univ.Choice):
     """
     componentType = namedtype.NamedTypes(
         namedtype.NamedType(
-            'ir', rfc2511.CertReqMessages().subtype(
+            'ir', rfc4211.CertReqMessages().subtype(
                 explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0)
             )
         ),
@@ -570,7 +572,7 @@ class PKIBody(univ.Choice):
             )
         ),
         namedtype.NamedType(
-            'cr', rfc2511.CertReqMessages().subtype(
+            'cr', rfc4211.CertReqMessages().subtype(
                 explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 2)
             )
         ),
@@ -580,7 +582,7 @@ class PKIBody(univ.Choice):
             )
         ),
         namedtype.NamedType(
-            'p10cr', rfc2314.CertificationRequest().subtype(
+            'p10cr', rfc6402.CertificationRequest().subtype(
                 explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 4)
             )
         ),
@@ -595,7 +597,7 @@ class PKIBody(univ.Choice):
             )
         ),
         namedtype.NamedType(
-            'kur', rfc2511.CertReqMessages().subtype(
+            'kur', rfc4211.CertReqMessages().subtype(
                 explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 7)
             )
         ),
@@ -605,7 +607,7 @@ class PKIBody(univ.Choice):
             )
         ),
         namedtype.NamedType(
-            'krr', rfc2511.CertReqMessages().subtype(
+            'krr', rfc4211.CertReqMessages().subtype(
                 explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 9)
             )
         ),
@@ -625,7 +627,7 @@ class PKIBody(univ.Choice):
             )
         ),
         namedtype.NamedType(
-            'ccr', rfc2511.CertReqMessages().subtype(
+            'ccr', rfc4211.CertReqMessages().subtype(
                 explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 13)
             )
         ),

--- a/pyasn1_alt_modules/rfc4211.py
+++ b/pyasn1_alt_modules/rfc4211.py
@@ -3,6 +3,10 @@
 # This file is part of pyasn1-alt-modules software.
 #
 # Created by Stanisław Pitucha with asn1ate tool.
+# Modified by Russ Housley to import from RFC 5280 instead of RFC 3280, to
+#   import from RFC 5252 instead of RFC 3852, and to include an opentype map
+#   for AttributeTypeAndValue.
+#
 # Copyright (c) 2005-2020, Ilya Etingof <etingof@gmail.com>
 # Copyright (c) 2021, Vigil Security, LLC
 # License: http://vigilsec.com/pyasn1-alt-modules-license.txt
@@ -17,11 +21,15 @@ from pyasn1.type import char
 from pyasn1.type import constraint
 from pyasn1.type import namedtype
 from pyasn1.type import namedval
+from pyasn1.type import opentype
 from pyasn1.type import tag
 from pyasn1.type import univ
 
-from pyasn1_alt_modules import rfc3280
-from pyasn1_alt_modules import rfc3852
+from pyasn1_alt_modules import rfc5280
+from pyasn1_alt_modules import rfc5652
+from pyasn1_alt_modules import opentypemap
+
+cmsAttributesMap = opentypemap.get('cmsAttributesMap')
 
 MAX = float('inf')
 
@@ -51,7 +59,7 @@ class SinglePubInfo(univ.Sequence):
 SinglePubInfo.componentType = namedtype.NamedTypes(
     namedtype.NamedType('pubMethod', univ.Integer(
         namedValues=namedval.NamedValues(('dontCare', 0), ('x500', 1), ('web', 2), ('ldap', 3)))),
-    namedtype.OptionalNamedType('pubLocation', rfc3280.GeneralName())
+    namedtype.OptionalNamedType('pubLocation', rfc5280.GeneralName())
 )
 
 
@@ -64,7 +72,7 @@ class PKMACValue(univ.Sequence):
 
 
 PKMACValue.componentType = namedtype.NamedTypes(
-    namedtype.NamedType('algId', rfc3280.AlgorithmIdentifier()),
+    namedtype.NamedType('algId', rfc5280.AlgorithmIdentifier()),
     namedtype.NamedType('value', univ.BitString())
 )
 
@@ -78,7 +86,7 @@ POPOSigningKeyInput.componentType = namedtype.NamedTypes(
         'authInfo', univ.Choice(
             componentType=namedtype.NamedTypes(
                 namedtype.NamedType(
-                    'sender', rfc3280.GeneralName().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0))
+                    'sender', rfc5280.GeneralName().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0))
                 ),
                 namedtype.NamedType(
                     'publicKeyMAC', PKMACValue()
@@ -86,7 +94,7 @@ POPOSigningKeyInput.componentType = namedtype.NamedTypes(
             )
         )
     ),
-    namedtype.NamedType('publicKey', rfc3280.SubjectPublicKeyInfo())
+    namedtype.NamedType('publicKey', rfc5280.SubjectPublicKeyInfo())
 )
 
 
@@ -97,7 +105,7 @@ class POPOSigningKey(univ.Sequence):
 POPOSigningKey.componentType = namedtype.NamedTypes(
     namedtype.OptionalNamedType('poposkInput', POPOSigningKeyInput().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0))),
-    namedtype.NamedType('algorithmIdentifier', rfc3280.AlgorithmIdentifier()),
+    namedtype.NamedType('algorithmIdentifier', rfc5280.AlgorithmIdentifier()),
     namedtype.NamedType('signature', univ.BitString())
 )
 
@@ -106,7 +114,7 @@ class Attributes(univ.SetOf):
     pass
 
 
-Attributes.componentType = rfc3280.Attribute()
+Attributes.componentType = rfc5280.Attribute()
 
 
 class PrivateKeyInfo(univ.Sequence):
@@ -115,7 +123,7 @@ class PrivateKeyInfo(univ.Sequence):
 
 PrivateKeyInfo.componentType = namedtype.NamedTypes(
     namedtype.NamedType('version', univ.Integer()),
-    namedtype.NamedType('privateKeyAlgorithm', rfc3280.AlgorithmIdentifier()),
+    namedtype.NamedType('privateKeyAlgorithm', rfc5280.AlgorithmIdentifier()),
     namedtype.NamedType('privateKey', univ.OctetString()),
     namedtype.OptionalNamedType('attributes',
                                 Attributes().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0)))
@@ -127,13 +135,13 @@ class EncryptedValue(univ.Sequence):
 
 
 EncryptedValue.componentType = namedtype.NamedTypes(
-    namedtype.OptionalNamedType('intendedAlg', rfc3280.AlgorithmIdentifier().subtype(
+    namedtype.OptionalNamedType('intendedAlg', rfc5280.AlgorithmIdentifier().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))),
-    namedtype.OptionalNamedType('symmAlg', rfc3280.AlgorithmIdentifier().subtype(
+    namedtype.OptionalNamedType('symmAlg', rfc5280.AlgorithmIdentifier().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))),
     namedtype.OptionalNamedType('encSymmKey', univ.BitString().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 2))),
-    namedtype.OptionalNamedType('keyAlg', rfc3280.AlgorithmIdentifier().subtype(
+    namedtype.OptionalNamedType('keyAlg', rfc5280.AlgorithmIdentifier().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 3))),
     namedtype.OptionalNamedType('valueHint', univ.OctetString().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 4))),
@@ -147,7 +155,7 @@ class EncryptedKey(univ.Choice):
 
 EncryptedKey.componentType = namedtype.NamedTypes(
     namedtype.NamedType('encryptedValue', EncryptedValue()),
-    namedtype.NamedType('envelopedData', rfc3852.EnvelopedData().subtype(
+    namedtype.NamedType('envelopedData', rfc5652.EnvelopedData().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0)))
 )
 
@@ -176,7 +184,7 @@ id_regInfo = _buildOid(id_pkip, 2)
 id_regInfo_certReq = _buildOid(id_regInfo, 2)
 
 
-class ProtocolEncrKey(rfc3280.SubjectPublicKeyInfo):
+class ProtocolEncrKey(rfc5280.SubjectPublicKeyInfo):
     pass
 
 
@@ -200,7 +208,8 @@ class AttributeTypeAndValue(univ.Sequence):
 
 AttributeTypeAndValue.componentType = namedtype.NamedTypes(
     namedtype.NamedType('type', univ.ObjectIdentifier()),
-    namedtype.NamedType('value', univ.Any())
+    namedtype.NamedType('value', univ.Any(),
+        openType=opentype.OpenType('type', cmsAttributesMap))
 )
 
 
@@ -217,7 +226,7 @@ POPOPrivKey.componentType = namedtype.NamedTypes(
                         univ.BitString().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 2))),
     namedtype.NamedType('agreeMAC',
                         PKMACValue().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 3))),
-    namedtype.NamedType('encryptedKey', rfc3852.EnvelopedData().subtype(
+    namedtype.NamedType('encryptedKey', rfc5652.EnvelopedData().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 4)))
 )
 
@@ -243,9 +252,9 @@ class OptionalValidity(univ.Sequence):
 
 
 OptionalValidity.componentType = namedtype.NamedTypes(
-    namedtype.OptionalNamedType('notBefore', rfc3280.Time().subtype(
+    namedtype.OptionalNamedType('notBefore', rfc5280.Time().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0))),
-    namedtype.OptionalNamedType('notAfter', rfc3280.Time().subtype(
+    namedtype.OptionalNamedType('notAfter', rfc5280.Time().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1)))
 )
 
@@ -255,25 +264,25 @@ class CertTemplate(univ.Sequence):
 
 
 CertTemplate.componentType = namedtype.NamedTypes(
-    namedtype.OptionalNamedType('version', rfc3280.Version().subtype(
+    namedtype.OptionalNamedType('version', rfc5280.Version().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))),
     namedtype.OptionalNamedType('serialNumber', univ.Integer().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))),
-    namedtype.OptionalNamedType('signingAlg', rfc3280.AlgorithmIdentifier().subtype(
+    namedtype.OptionalNamedType('signingAlg', rfc5280.AlgorithmIdentifier().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 2))),
-    namedtype.OptionalNamedType('issuer', rfc3280.Name().subtype(
+    namedtype.OptionalNamedType('issuer', rfc5280.Name().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 3))),
     namedtype.OptionalNamedType('validity', OptionalValidity().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 4))),
-    namedtype.OptionalNamedType('subject', rfc3280.Name().subtype(
+    namedtype.OptionalNamedType('subject', rfc5280.Name().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 5))),
-    namedtype.OptionalNamedType('publicKey', rfc3280.SubjectPublicKeyInfo().subtype(
+    namedtype.OptionalNamedType('publicKey', rfc5280.SubjectPublicKeyInfo().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 6))),
-    namedtype.OptionalNamedType('issuerUID', rfc3280.UniqueIdentifier().subtype(
+    namedtype.OptionalNamedType('issuerUID', rfc5280.UniqueIdentifier().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 7))),
-    namedtype.OptionalNamedType('subjectUID', rfc3280.UniqueIdentifier().subtype(
+    namedtype.OptionalNamedType('subjectUID', rfc5280.UniqueIdentifier().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 8))),
-    namedtype.OptionalNamedType('extensions', rfc3280.Extensions().subtype(
+    namedtype.OptionalNamedType('extensions', rfc5280.Extensions().subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 9)))
 )
 
@@ -328,7 +337,7 @@ class CertId(univ.Sequence):
 
 
 CertId.componentType = namedtype.NamedTypes(
-    namedtype.NamedType('issuer', rfc3280.GeneralName()),
+    namedtype.NamedType('issuer', rfc5280.GeneralName()),
     namedtype.NamedType('serialNumber', univ.Integer())
 )
 
@@ -358,7 +367,7 @@ EncKeyWithID.componentType = namedtype.NamedTypes(
         'identifier', univ.Choice(
             componentType=namedtype.NamedTypes(
                 namedtype.NamedType('string', char.UTF8String()),
-                namedtype.NamedType('generalName', rfc3280.GeneralName())
+                namedtype.NamedType('generalName', rfc5280.GeneralName())
             )
         )
     )
@@ -377,9 +386,9 @@ class PBMParameter(univ.Sequence):
 
 PBMParameter.componentType = namedtype.NamedTypes(
     namedtype.NamedType('salt', univ.OctetString()),
-    namedtype.NamedType('owf', rfc3280.AlgorithmIdentifier()),
+    namedtype.NamedType('owf', rfc5280.AlgorithmIdentifier()),
     namedtype.NamedType('iterationCount', univ.Integer()),
-    namedtype.NamedType('mac', rfc3280.AlgorithmIdentifier())
+    namedtype.NamedType('mac', rfc5280.AlgorithmIdentifier())
 )
 
 id_regCtrl_regToken = _buildOid(id_regCtrl, 1)
@@ -395,3 +404,17 @@ id_ct_encKeyWithID = _buildOid(id_ct, 21)
 
 class RegToken(char.UTF8String):
     pass
+
+
+# Update the CMS Attribute Map
+
+_cmsAttributesMapUpdate = {
+    id_regCtrl_regToken: RegToken(),
+    id_regCtrl_authenticator: Authenticator(),
+    id_regCtrl_pkiPublicationInfo: PKIPublicationInfo(),
+    id_regCtrl_pkiArchiveOptions: PKIArchiveOptions(),
+    id_regCtrl_oldCertID: OldCertId(),
+    id_regCtrl_protocolEncrKey: rfc5280.SubjectPublicKeyInfo(),
+}
+
+cmsAttributesMap.update(_cmsAttributesMapUpdate)

--- a/tests/test_rfc4211.py
+++ b/tests/test_rfc4211.py
@@ -34,7 +34,6 @@ xfu5YVWi81/fw8QQ6X6YGHFQkomLd7jxakVyjxSng9BhO6GpjJNF
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.pem_text)
         asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
-
         self.assertFalse(rest)
         self.assertTrue(asn1Object.prettyPrint())
         self.assertEqual(substrate, der_encoder(asn1Object))
@@ -46,6 +45,28 @@ xfu5YVWi81/fw8QQ6X6YGHFQkomLd7jxakVyjxSng9BhO6GpjJNF
             count += 1
 
         self.assertEqual(1, count)
+
+    def testOpenTypes(self):
+        substrate = pem.readBase64fromText(self.pem_text)
+        asn1Object, rest = der_decoder(substrate,
+            asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        count = 0
+        
+        for ctrl in asn1Object[0][0]['controls']:
+
+            if ctrl['type'] == rfc4211.id_regCtrl_regToken:
+                self.assertEqual(u'11111', ctrl['value'])
+                count += 1
+            
+            if ctrl['type'] == rfc4211.id_regCtrl_authenticator:
+                self.assertEqual(u'server_magic', ctrl['value'])
+                count += 1
+
+        self.assertEqual(2, count)
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])


### PR DESCRIPTION
- Update RFC4210 by Russ Housley to import from RFC 5280, RFC 4211, and
  RFC6402 instead of earlier RFCs covering the same things

- Update RFC4210 o import from RFC 5280 and RFC5252 instead of earlier
  RFCs covering the same things, and to include an opentype map for
  AttributeTypeAndValue