### PR TITLE
Improve test for RFC 6486

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,7 @@ Revision 0.4.1, released XX-XX-2021
 - Add RFC5794 providing the ARIA Encryption Algorithm
 - Add RFC9174 providing naming and extended key usage for the Delay-Tolerant
   Networking TCP Convergence Layer Version 4
+- Improve the test for RFC 6486
 
 Revision 0.4.0, released 10-07-2021
 -----------------------------------

--- a/tests/test_rfc6486.py
+++ b/tests/test_rfc6486.py
@@ -85,8 +85,12 @@ C9ijmXiajracUe+7eCluqgXRE8yRtnscWoA/9fVFz1lPwgEeNHLoaK7Sqew=
 
         self.assertEqual(0, asn1Object['version'])
 
+        counter = 0
         for f in asn1Object['fileList']:
             self.assertEqual('ZXSGBDBkL82TFGHuE4VOYtJP-E4.crl', f['file'])
+            counter += 1
+    
+        self.assertEqual(1, counter)
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.manifest_pem_text)
@@ -109,8 +113,12 @@ C9ijmXiajracUe+7eCluqgXRE8yRtnscWoA/9fVFz1lPwgEeNHLoaK7Sqew=
         self.assertEqual(substrate, der_encoder(asn1Object))
         self.assertEqual(0, asn1Object['version'])
 
+        counter = 0
         for f in asn1Object['fileList']:
             self.assertEqual('ZXSGBDBkL82TFGHuE4VOYtJP-E4.crl', f['file'])
+            counter += 1
+    
+        self.assertEqual(1, counter)
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])


### PR DESCRIPTION
Improve test for RFC 6486 by making sure that there is a file name