### PR TITLE
Include WITH COMPONENTS constraints for RFC 3709

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,12 +15,12 @@ Revision 0.4.1, released XX-XX-2022
 - Improve the test for RFC6486
 - Improve the test for RFC9174
 - Update the copyright lines for 2022
+- Improve RFC3709 to enforce WITH CPMPONENTS constraints
 
 Revision 0.4.0, released 10-07-2021
 -----------------------------------
 - Added opentypemap to manage the open type maps for all modules
 - Add RFC9092 providing CMS Content Type for Geofeed Data
-
 
 Revision 0.3.2, released 14-06-2021
 -----------------------------------

--- a/pyasn1_alt_modules/rfc3709.py
+++ b/pyasn1_alt_modules/rfc3709.py
@@ -4,6 +4,8 @@
 # Created by Russ Housley with assistance from asn1ate v.0.6.0.
 # Modified by Russ Housley to add maps for use with opentypes.
 # Modified by Russ Housley to include the opentypemap manager.
+# Modified by Russ Housley to add WITH COMPONENTS constraints for
+#   requirements from the text, but stated in the ASN.1 module.
 #
 # Copyright (c) 2019-2022, Vigil Security, LLC
 # License: http://vigilsec.com/pyasn1-alt-modules-license.txt
@@ -135,6 +137,13 @@ LogotypeData.componentType = namedtype.NamedTypes(
             tag.tagFormatSimple, 1)))
 )
 
+LogotypeData.subtypeSpec = constraint.ConstraintsUnion(
+    constraint.WithComponentsConstraint(
+        ('image', constraint.ComponentPresentConstraint())),
+    constraint.WithComponentsConstraint(
+        ('audio', constraint.ComponentPresentConstraint()))
+)
+
 
 class LogotypeReference(univ.Sequence):
     pass
@@ -198,6 +207,17 @@ LogotypeExtn.componentType = namedtype.NamedTypes(
     namedtype.OptionalNamedType('otherLogos', univ.SequenceOf(
         componentType=OtherLogotypeInfo()).subtype(explicitTag=tag.Tag(
             tag.tagClassContext, tag.tagFormatSimple, 3)))
+)
+
+LogotypeExtn.subtypeSpec = constraint.ConstraintsUnion(
+    constraint.WithComponentsConstraint(
+        ('communityLogos', constraint.ComponentPresentConstraint())),
+    constraint.WithComponentsConstraint(
+        ('issuerLogo', constraint.ComponentPresentConstraint())),
+    constraint.WithComponentsConstraint(
+        ('subjectLogo', constraint.ComponentPresentConstraint())),
+    constraint.WithComponentsConstraint(
+        ('otherLogos', constraint.ComponentPresentConstraint()))
 )
 
 


### PR DESCRIPTION
Include  WITH COMPONENTS constraints for requirements from the text, but stated in the ASN.1 module.