### PR TITLE
Add support for RFC 2898

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+Revision 0.4.2, released XX-XX-2022
+-----------------------------------
+- Added RFC2898 providing PKCS #5, Version 2.0
+
 Revision 0.4.1, released 16-02-2022
 -----------------------------------
 - Update RFC4210 to import from RFC 5280, RFC 4211, and RFC6402 instead of

--- a/pyasn1_alt_modules/rfc2898.py
+++ b/pyasn1_alt_modules/rfc2898.py
@@ -1,0 +1,72 @@
+#
+# This file is part of pyasn1-alt-modules software.
+#
+# Created by Russ Housley.
+#
+# Copyright (c) 2022, Vigil Security, LLC
+# License: http://vigilsec.com/pyasn1-alt-modules-license.txt
+#
+# PKCS #5: Password-Based Cryptography Specification, Version 2.0
+#
+# ASN.1 source from:
+# https://www.rfc-editor.org/rfc/rfc2898.txt
+# https://www.rfc-editor.org/rfc/rfc8018.txt
+#
+
+from pyasn1_alt_modules import rfc8018
+
+
+# PKCS#5 Version 2.1 is backward compatible with PKCS#5 Version 2.0,
+# so all of the definitions can be imported from the newer document.
+
+rsadsi = rfc8018.rsadsi
+
+pkcs = rfc8018.pkcs
+
+digestAlgorithm = rfc8018.digestAlgorithm
+
+encryptionAlgorithm = rfc8018.encryptionAlgorithm
+
+pkcs_5 = rfc8018.pkcs_5
+
+id_PBKDF2 = rfc8018.id_PBKDF2
+
+PBKDF2_params = rfc8018.PBKDF2_params
+
+id_hmacWithSHA1 = rfc8018.id_hmacWithSHA1
+
+algid_hmacWithSHA1 = rfc8018.algid_hmacWithSHA1
+
+pbeWithMD2AndDES_CBC = rfc8018.pbeWithMD2AndDES_CBC
+
+pbeWithMD2AndRC2_CBC = rfc8018.pbeWithMD2AndRC2_CBC
+
+pbeWithMD5AndDES_CBC = rfc8018.pbeWithMD5AndDES_CBC
+
+pbeWithMD5AndRC2_CBC = rfc8018.pbeWithMD5AndRC2_CBC
+
+pbeWithSHA1AndDES_CBC = rfc8018.pbeWithSHA1AndDES_CBC
+
+pbeWithSHA1AndRC2_CBC = rfc8018.pbeWithSHA1AndRC2_CBC
+
+PBEParameter = rfc8018.PBEParameter
+
+id_PBES2 = rfc8018.id_PBES2
+
+PBES2_params = rfc8018.PBES2_params
+
+id_PBMAC1 = rfc8018.id_PBMAC1
+
+PBMAC1_params = rfc8018.PBMAC1_params
+
+desCBC = rfc8018.desCBC
+
+des_EDE3_CBC = rfc8018.des_EDE3_CBC
+
+rc2CBC = rfc8018.rc2CBC
+
+RC2_CBC_Parameter = rfc8018.RC2_CBC_Parameter
+
+rc5_CBC_PAD = rfc8018.rc5_CBC_PAD
+
+RC5_CBC_Parameters = rfc8018.RC5_CBC_Parameters

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -22,6 +22,7 @@ suite = unittest.TestLoader().loadTestsFromNames(
      'tests.test_rfc2634.suite',
      'tests.test_rfc2743.suite',
      'tests.test_rfc2876.suite',
+     'tests.test_rfc2898.suite',
      'tests.test_rfc2985.suite',
      'tests.test_rfc2986.suite',
      'tests.test_rfc3058.suite',

--- a/tests/test_rfc2898.py
+++ b/tests/test_rfc2898.py
@@ -1,0 +1,58 @@
+#
+# This file is part of pyasn1-alt-modules software.
+#
+# Created by Russ Housley
+# Copyright (c) 2019-2022, Vigil Security, LLC
+# License: http://vigilsec.com/pyasn1-alt-modules-license.txt
+#
+import sys
+import unittest
+
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
+
+from pyasn1_alt_modules import pem
+from pyasn1_alt_modules import rfc5652
+from pyasn1_alt_modules import rfc2898
+
+
+class PWRITestCase(unittest.TestCase):
+    rfc3211_ex1_pem_text = """\
+o1MCAQCgGgYJKoZIhvcNAQUMMA0ECBI0Vnh4VjQSAgEFMCAGCyqGSIb3DQEJEAMJMBEGBSsO
+AwIHBAjv5ZjvIbM9bQQQuBslZe43PKbe3KJqF4sMEA==
+"""
+
+    def setUp(self):
+        self.asn1Spec = rfc5652.RecipientInfo()
+
+    def testDerCodec(self):
+        substrate = pem.readBase64fromText(self.rfc3211_ex1_pem_text)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        alg_oid = asn1Object['pwri']['keyDerivationAlgorithm']['algorithm']
+
+        self.assertEqual(rfc2898.id_PBKDF2, alg_oid)
+
+    def testOpenTypes(self):
+        substrate = pem.readBase64fromText(self.rfc3211_ex1_pem_text)
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        icount = (asn1Object['pwri']['keyDerivationAlgorithm']
+                            ['parameters']['iterationCount'])
+
+        self.assertEqual(5, icount)
+
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Module and test for RFC 2898.  Since PKCS#5 v2.1 is backward compatible with PKCS#5 v2.0, everything can be imported from rfc8018.py.