### PR TITLE
Align RFC3739 SemanticsInformation with EID7802

### DIFF
--- a/pyasn1_alt_modules/rfc3739.py
+++ b/pyasn1_alt_modules/rfc3739.py
@@ -5,7 +5,8 @@
 # Modified by Russ Housley to add WithComponentsConstraints to
 #   enforce the requirements that are indicated in comments.
 # Modified by Russ Housley to include the opentypemap manager.
-# Modified by CBonnell to align the SemanticsInformation definition with https://www.rfc-editor.org/errata/eid7802
+# Modified by CBonnell to align the SemanticsInformation
+#   definition with https://www.rfc-editor.org/errata/eid7802.
 #
 # Copyright (c) 2019-2024, Vigil Security, LLC
 # License: http://vigilsec.com/pyasn1-alt-modules-license.txt
@@ -14,6 +15,7 @@
 #
 # ASN.1 source from:
 # https://www.rfc-editor.org/rfc/rfc3739.txt
+# https://www.rfc-editor.org/errata/eid7802
 #
 
 from pyasn1.type import char

--- a/pyasn1_alt_modules/rfc3739.py
+++ b/pyasn1_alt_modules/rfc3739.py
@@ -5,6 +5,7 @@
 # Modified by Russ Housley to add WithComponentsConstraints to
 #   enforce the requirements that are indicated in comments.
 # Modified by Russ Housley to include the opentypemap manager.
+# Modified by CBonnell to align the SemanticsInformation definition with https://www.rfc-editor.org/errata/eid7802
 #
 # Copyright (c) 2019-2024, Vigil Security, LLC
 # License: http://vigilsec.com/pyasn1-alt-modules-license.txt
@@ -158,14 +159,14 @@ class QCStatements(univ.SequenceOf):
 
 class SemanticsInformation(univ.Sequence):
     componentType = namedtype.NamedTypes(
-        namedtype.OptionalNamedType('semanticsIndentifier',
+        namedtype.OptionalNamedType('semanticsIdentifier',
             univ.ObjectIdentifier()),
         namedtype.OptionalNamedType('nameRegistrationAuthorities',
             NameRegistrationAuthorities())
     )
     subtypeSpec = constraint.ConstraintsUnion(
         constraint.WithComponentsConstraint(
-            ('semanticsIndentifier', constraint.ComponentPresentConstraint())),
+            ('semanticsIdentifier', constraint.ComponentPresentConstraint())),
         constraint.WithComponentsConstraint(
             ('nameRegistrationAuthorities', constraint.ComponentPresentConstraint()))
     )


### PR DESCRIPTION
Test case:

```python
from pyasn1_alt_modules import rfc3739
from pyasn1.type import univ

si = rfc3739.SemanticsInformation()
si['semanticsIdentifier'] = univ.ObjectIdentifier('1.2.3.4')

try:
    si['semanticsIndentifier'] = univ.ObjectIdentifier('1.2.3.4')

    assert False
except KeyError:
    pass
```