### PR TITLE
Add support for Python 3.12

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+Revision 0.4.4, released ??-??-2024
+-----------------------------------
+Added support for Python 3.12, and dropped support for Python 3.5.
+
 Revision 0.4.3, released 08-02-2024
 -----------------------------------
 - Update the copyright comment lines for 2024

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Alternative ASN.1 modules for pyasn1
 The `pyasn1-alt-modules` package contains a collection of
 [ASN.1](https://www.itu.int/rec/dologin_pub.asp?lang=e&id=T-REC-X.208-198811-W!!PDF-E&type=items)
 data structures expressed as Python classes based on [pyasn1](https://github.com/etingof/pyasn1)
-data model.
+data model. Maintenance of pyasn1 has shifted to [pyasn1-maint](https://github.com/pyasn1/pyasn1).
 
 It seems that [pyasn1-modules](https://github.com/etingof/pyasn1-modules) is no
 longer being maintained.  As a result, the `pyasn1-alt-modules` package was
@@ -25,7 +25,7 @@ Feedback
 --------
 
 If something does not work as expected, 
-[open an issue](https://github.com/russhousley/pyasn1-alt-modules/issues) at GitHub.
+[open an issue](https://github.com/russhousley/pyasn1-alt-modules/issues) on GitHub.
  
 Additional module contributions are welcome via GitHub pull requests.
 

--- a/setup.py
+++ b/setup.py
@@ -34,13 +34,13 @@ Operating System :: OS Independent
 Programming Language :: Python :: 2
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
 Programming Language :: Python :: 3.11
+Programming Language :: Python :: 3.12
 Topic :: Communications
 Topic :: System :: Monitoring
 Topic :: System :: Networking :: Monitoring
@@ -99,7 +99,7 @@ params.update(
      'classifiers': [x for x in classifiers.split('\n') if x],
      'license': 'BSD-2-Clause',
      'packages': ['pyasn1_alt_modules'],
-     'python_requires': '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*'})
+     'python_requires': '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*'})
 
 class PyTest(Command):
     user_options = []

--- a/tox.ini
+++ b/tox.ini
@@ -27,10 +27,6 @@ commands =
 deps = {[testenv:unittest]deps}
 commands = {[testenv:unittest]commands}
 
-[testenv:py35-unittest]
-deps = {[testenv:unittest]deps}
-commands = {[testenv:unittest]commands}
-
 [testenv:py36-unittest]
 deps = {[testenv:unittest]deps}
 commands = {[testenv:unittest]commands}
@@ -43,8 +39,24 @@ commands = {[testenv:unittest]commands}
 deps = {[testenv:unittest]deps}
 commands = {[testenv:unittest]commands}
 
+[testenv:py39-unittest]
+deps = {[testenv:unittest]deps}
+commands = {[testenv:unittest]commands}
+
+[testenv:py310-unittest]
+deps = {[testenv:unittest]deps}
+commands = {[testenv:unittest]commands}
+
+[testenv:py311-unittest]
+deps = {[testenv:unittest]deps}
+commands = {[testenv:unittest]commands}
+
+[testenv:py312-unittest]
+deps = {[testenv:unittest]deps}
+commands = {[testenv:unittest]commands}
+
 [testenv:cover]
-basepython = python3.7
+basepython = python3.11
 setenv =
     {[testenv]setenv}
     PYTHON=coverage run --parallel-mode


### PR DESCRIPTION
Added support for Python 3.12.  Dropped support for Python 3.5.  Add pointer to https://github.com/pyasn1/pyasn1 to README.md.