### PR TITLE
Add support for RFC 8954

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@ Revision 0.4.4, released ??-??-2024
 -----------------------------------
 - Added support for Python 3.12, and dropped support for Python 3.5.
 - Added RFC9548 for Generating Transport Key Containers Using the GOST Algorithms
+- Added RFC8964 for Online Certificate Status Protocol (OCSP) with Nonce constraints
 
 Revision 0.4.3, released 08-02-2024
 -----------------------------------

--- a/pyasn1_alt_modules/rfc8954.py
+++ b/pyasn1_alt_modules/rfc8954.py
@@ -1,0 +1,238 @@
+#
+# This file is part of pyasn1-alt-modules software.
+#
+# Created by Russ Housley.
+#
+# Copyright (c) 2024, Vigil Security, LLC
+# License: http://vigilsec.com/pyasn1-alt-modules-license.txt
+#
+# Online Certificate Status Protocol (OCSP) with nonce size constraints
+#
+# ASN.1 source from:
+# https://www.rfc-editor.org/rfc/rfc6960.txt
+# https://www.rfc-editor.org/rfc/rfc8954.txt
+#
+
+from pyasn1.type import char
+from pyasn1.type import constraint
+from pyasn1.type import namedtype
+from pyasn1.type import tag
+from pyasn1.type import univ
+from pyasn1.type import useful
+
+from pyasn1_alt_modules import rfc2560
+from pyasn1_alt_modules import rfc5280
+from pyasn1_alt_modules import opentypemap
+
+certificateExtensionsMap = opentypemap.get('certificateExtensionsMap')
+
+ocspResponseMap = opentypemap.get('ocspResponseMap')
+
+MAX = float('inf')
+
+
+# Imports from RFC 5280
+
+AlgorithmIdentifier = rfc5280.AlgorithmIdentifier
+AuthorityInfoAccessSyntax = rfc5280.AuthorityInfoAccessSyntax
+Certificate = rfc5280.Certificate
+CertificateSerialNumber = rfc5280.CertificateSerialNumber
+CRLReason = rfc5280.CRLReason
+Extensions = rfc5280.Extensions
+GeneralName = rfc5280.GeneralName
+Name = rfc5280.Name
+
+id_kp = rfc5280.id_kp
+
+id_ad_ocsp = rfc5280.id_ad_ocsp
+
+
+# Imports from the original OCSP module in RFC 2560
+
+AcceptableResponses = rfc2560.AcceptableResponses
+ArchiveCutoff = rfc2560.ArchiveCutoff
+CertStatus = rfc2560.CertStatus
+KeyHash = rfc2560.KeyHash
+OCSPResponse = rfc2560.OCSPResponse
+OCSPResponseStatus = rfc2560.OCSPResponseStatus
+ResponseBytes = rfc2560.ResponseBytes
+RevokedInfo = rfc2560.RevokedInfo
+UnknownInfo = rfc2560.UnknownInfo
+Version = rfc2560.Version
+
+id_kp_OCSPSigning = rfc2560.id_kp_OCSPSigning
+
+id_pkix_ocsp = rfc2560.id_pkix_ocsp
+id_pkix_ocsp_archive_cutoff = rfc2560.id_pkix_ocsp_archive_cutoff
+id_pkix_ocsp_basic = rfc2560.id_pkix_ocsp_basic
+id_pkix_ocsp_crl = rfc2560.id_pkix_ocsp_crl
+id_pkix_ocsp_nocheck = rfc2560.id_pkix_ocsp_nocheck
+id_pkix_ocsp_nonce = rfc2560.id_pkix_ocsp_nonce
+id_pkix_ocsp_response = rfc2560.id_pkix_ocsp_response
+id_pkix_ocsp_service_locator = rfc2560.id_pkix_ocsp_service_locator
+
+
+# Additional object identifiers
+
+id_pkix_ocsp_pref_sig_algs = id_pkix_ocsp + (8, )
+id_pkix_ocsp_extended_revoke = id_pkix_ocsp + (9, )
+
+
+# Updated structures (mostly to improve openTypes support)
+
+class CertID(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('hashAlgorithm', AlgorithmIdentifier()),
+        namedtype.NamedType('issuerNameHash', univ.OctetString()),
+        namedtype.NamedType('issuerKeyHash', univ.OctetString()),
+        namedtype.NamedType('serialNumber', CertificateSerialNumber())
+    )
+
+
+class SingleResponse(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('certID', CertID()),
+        namedtype.NamedType('certStatus', CertStatus()),
+        namedtype.NamedType('thisUpdate', useful.GeneralizedTime()),
+        namedtype.OptionalNamedType('nextUpdate', useful.GeneralizedTime().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))),
+        namedtype.OptionalNamedType('singleExtensions', Extensions().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1)))
+    )
+
+
+class ResponderID(univ.Choice):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('byName', Name().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))),
+        namedtype.NamedType('byKey', KeyHash().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 2)))
+    )
+
+
+class ResponseData(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.DefaultedNamedType('version', Version('v1').subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))),
+        namedtype.NamedType('responderID', ResponderID()),
+        namedtype.NamedType('producedAt', useful.GeneralizedTime()),
+        namedtype.NamedType('responses', univ.SequenceOf(
+            componentType=SingleResponse())),
+        namedtype.OptionalNamedType('responseExtensions', Extensions().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1)))
+    )
+
+
+class BasicOCSPResponse(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('tbsResponseData', ResponseData()),
+        namedtype.NamedType('signatureAlgorithm', AlgorithmIdentifier()),
+        namedtype.NamedType('signature', univ.BitString()),
+        namedtype.OptionalNamedType('certs', univ.SequenceOf(
+            componentType=Certificate()).subtype(explicitTag=tag.Tag(
+                tag.tagClassContext, tag.tagFormatSimple, 0)))
+    )
+
+
+class Request(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('reqCert', CertID()),
+        namedtype.OptionalNamedType('singleRequestExtensions', Extensions().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0)))
+    )
+
+
+class Signature(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('signatureAlgorithm', AlgorithmIdentifier()),
+        namedtype.NamedType('signature', univ.BitString()),
+        namedtype.OptionalNamedType('certs', univ.SequenceOf(
+            componentType=Certificate()).subtype(explicitTag=tag.Tag(
+                tag.tagClassContext, tag.tagFormatSimple, 0)))
+    )
+
+
+class TBSRequest(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.DefaultedNamedType('version', Version('v1').subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))),
+        namedtype.OptionalNamedType('requestorName', GeneralName().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))),
+        namedtype.NamedType('requestList', univ.SequenceOf(
+            componentType=Request())),
+        namedtype.OptionalNamedType('requestExtensions', Extensions().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 2)))
+    )
+
+
+class OCSPRequest(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('tbsRequest', TBSRequest()),
+        namedtype.OptionalNamedType('optionalSignature', Signature().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0)))
+    )
+
+
+# Previously omitted structure
+
+class ServiceLocator(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('issuer', Name()),
+        namedtype.NamedType('locator', AuthorityInfoAccessSyntax())
+    )
+
+
+# Additional structures
+
+class CrlID(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.OptionalNamedType('crlUrl', char.IA5String().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))),
+        namedtype.OptionalNamedType('crlNum', univ.Integer().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))),
+        namedtype.OptionalNamedType('crlTime', useful.GeneralizedTime().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 2)))
+    )
+
+
+class PreferredSignatureAlgorithm(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('sigIdentifier', AlgorithmIdentifier()),
+        namedtype.OptionalNamedType('certIdentifier', AlgorithmIdentifier())
+    )
+
+
+class PreferredSignatureAlgorithms(univ.SequenceOf):
+    componentType = PreferredSignatureAlgorithm()
+
+
+class Nonce(univ.OctetString):
+    subtypeSpec = constraint.ValueSizeConstraint(1, 32)
+
+
+# Update the OCSP Response Map
+
+_ocspResponseMapUpdate = {
+    id_pkix_ocsp_basic: BasicOCSPResponse(),
+}
+
+ocspResponseMap.update(_ocspResponseMapUpdate)
+
+
+# Update the Certificate Extension Extensions Map
+
+_certificateExtensionsMapUpdate = {
+    # Certificate Extension
+    id_pkix_ocsp_nocheck: univ.Null(""),
+    # OCSP Request Extensions
+    id_pkix_ocsp_nonce: Nonce(),
+    id_pkix_ocsp_response: AcceptableResponses(),
+    id_pkix_ocsp_service_locator: ServiceLocator(),
+    id_pkix_ocsp_pref_sig_algs: PreferredSignatureAlgorithms(),
+    # OCSP Response Extensions
+    id_pkix_ocsp_crl: CrlID(),
+    id_pkix_ocsp_archive_cutoff: ArchiveCutoff(),
+    id_pkix_ocsp_extended_revoke: univ.Null(""),
+}
+
+certificateExtensionsMap.update(_certificateExtensionsMapUpdate)

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -159,6 +159,7 @@ suite = unittest.TestLoader().loadTestsFromNames(
      'tests.test_rfc8769.suite',
      'tests.test_rfc8894.suite',
      'tests.test_rfc8951.suite',
+     'tests.test_rfc8954.suite',
      'tests.test_rfc8994.suite',
      'tests.test_rfc8995.suite',
      'tests.test_rfc9044.suite',

--- a/tests/test_rfc8954.py
+++ b/tests/test_rfc8954.py
@@ -1,0 +1,192 @@
+#
+# This file is part of pyasn1-alt-modules software.
+#
+# Created by Russ Housley
+# Copyright (c) 2024, Vigil Security, LLC
+# License: http://vigilsec.com/pyasn1-alt-modules-license.txt
+#
+import sys
+import unittest
+
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
+from pyasn1.type import error
+from pyasn1.type import univ
+
+from pyasn1_alt_modules import pem
+from pyasn1_alt_modules import rfc5280
+from pyasn1_alt_modules import rfc4055
+from pyasn1_alt_modules import rfc8954
+from pyasn1_alt_modules import opentypemap
+
+
+class OCSPRequestTestCase(unittest.TestCase):
+    ocsp_req_pem_text = """\
+MGowaDBBMD8wPTAJBgUrDgMCGgUABBS3ZrMV9C5Dko03aH13cEZeppg3wgQUkqR1LKSevoFE63n8
+isWVpesQdXMCBDXe9M+iIzAhMB8GCSsGAQUFBzABAgQSBBBjdJOiIW9EKJGELNNf/rdA
+"""
+
+    def setUp(self):
+        self.asn1Spec = rfc8954.OCSPRequest()
+
+    def testDerCodec(self):
+        certificateExtensionsMap = opentypemap.get('certificateExtensionsMap')
+
+        substrate = pem.readBase64fromText(self.ocsp_req_pem_text)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+        self.assertEqual(0, asn1Object['tbsRequest']['version'])
+
+        count = 0
+        for extn in asn1Object['tbsRequest']['requestExtensions']:
+            self.assertIn(extn['extnID'], certificateExtensionsMap)
+
+            ev, rest = der_decoder(extn['extnValue'],
+                asn1Spec=certificateExtensionsMap[extn['extnID']])
+            self.assertFalse(rest)
+            self.assertTrue(ev.prettyPrint())
+            self.assertEqual(extn['extnValue'], der_encoder(ev))
+            count += 1
+
+        self.assertEqual(1, count)
+
+    def testOpenTypes(self):
+        substrate = pem.readBase64fromText(self.ocsp_req_pem_text)
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+        self.assertEqual(0, asn1Object['tbsRequest']['version'])
+
+        for req in asn1Object['tbsRequest']['requestList']:
+            ha = req['reqCert']['hashAlgorithm']
+            self.assertEqual(rfc4055.id_sha1, ha['algorithm'])
+            self.assertEqual(univ.Null(""), ha['parameters'])
+
+
+class OCSPResponseTestCase(unittest.TestCase):
+    ocsp_resp_pem_text = """\
+MIIEvQoBAKCCBLYwggSyBgkrBgEFBQcwAQEEggSjMIIEnzCCAQ+hgYAwfjELMAkGA1UEBhMCQVUx
+EzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDEV
+MBMGA1UEAxMMc25tcGxhYnMuY29tMSAwHgYJKoZIhvcNAQkBFhFpbmZvQHNubXBsYWJzLmNvbRgP
+MjAxMjA0MTExNDA5MjJaMFQwUjA9MAkGBSsOAwIaBQAEFLdmsxX0LkOSjTdofXdwRl6mmDfCBBSS
+pHUspJ6+gUTrefyKxZWl6xB1cwIENd70z4IAGA8yMDEyMDQxMTE0MDkyMlqhIzAhMB8GCSsGAQUF
+BzABAgQSBBBjdJOiIW9EKJGELNNf/rdAMA0GCSqGSIb3DQEBBQUAA4GBADk7oRiCy4ew1u0N52QL
+RFpW+tdb0NfkV2Xyu+HChKiTThZPr9ZXalIgkJ1w3BAnzhbB0JX/zq7Pf8yEz/OrQ4GGH7HyD3Vg
+PkMu+J6I3A2An+bUQo99AmCbZ5/tSHtDYQMQt3iNbv1fk0yvDmh7UdKuXUNSyJdHeg27dMNy4k8A
+oIIC9TCCAvEwggLtMIICVqADAgECAgEBMA0GCSqGSIb3DQEBBQUAMH4xCzAJBgNVBAYTAkFVMRMw
+EQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxFTAT
+BgNVBAMTDHNubXBsYWJzLmNvbTEgMB4GCSqGSIb3DQEJARYRaW5mb0Bzbm1wbGFicy5jb20wHhcN
+MTIwNDExMTMyNTM1WhcNMTMwNDExMTMyNTM1WjB+MQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29t
+ZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMRUwEwYDVQQDEwxzbm1w
+bGFicy5jb20xIDAeBgkqhkiG9w0BCQEWEWluZm9Ac25tcGxhYnMuY29tMIGfMA0GCSqGSIb3DQEB
+AQUAA4GNADCBiQKBgQDDDU5HOnNV8I2CojxB8ilIWRHYQuaAjnjrETMOprouDHFXnwWqQo/I3m0b
+XYmocrh9kDefb+cgc7+eJKvAvBqrqXRnU38DmQU/zhypCftGGfP8xjuBZ1n23lR3hplN1yYA0J2X
+SgBaAg6e8OsKf1vcX8Es09rDo8mQpt4G2zR56wIDAQABo3sweTAJBgNVHRMEAjAAMCwGCWCGSAGG
++EIBDQQfFh1PcGVuU1NMIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQU8Ys2dpJFLMHl
+yY57D4BNmlqnEcYwHwYDVR0jBBgwFoAU8Ys2dpJFLMHlyY57D4BNmlqnEcYwDQYJKoZIhvcNAQEF
+BQADgYEAWR0uFJVlQId6hVpUbgXFTpywtNitNXFiYYkRRv77McSJqLCa/c1wnuLmqcFcuRUK0oN6
+8ZJDP2HDDKe8MCZ8+sx+CF54eM8VCgN9uQ9XyE7x9XrXDd3Uw9RJVaWSIezkNKNeBE0lDM2jUjC4
+HAESdf7nebz1wtqAOXE1jWF/y8g=
+"""
+
+    def setUp(self):
+        self.asn1Spec = rfc8954.OCSPResponse()
+
+    def testDerCodec(self):
+        ocspResponseMap = opentypemap.get('ocspResponseMap')
+        certificateExtensionsMap = opentypemap.get('certificateExtensionsMap')
+
+        substrate = pem.readBase64fromText(self.ocsp_resp_pem_text)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+        self.assertEqual(0, asn1Object['responseStatus'])
+
+        rb = asn1Object['responseBytes']
+        self.assertIn(rb['responseType'], ocspResponseMap)
+
+        resp, rest = der_decoder(rb['response'],
+            asn1Spec=ocspResponseMap[rb['responseType']])
+        self.assertFalse(rest)
+        self.assertTrue(resp.prettyPrint())
+        self.assertEqual(rb['response'], der_encoder(resp))
+        self.assertEqual(0, resp['tbsResponseData']['version'])
+
+        count = 0
+        for extn in resp['tbsResponseData']['responseExtensions']:
+            self.assertIn(extn['extnID'], certificateExtensionsMap)
+            ev, rest = der_decoder(extn['extnValue'],
+                asn1Spec=certificateExtensionsMap[extn['extnID']])
+            self.assertFalse(rest)
+            self.assertTrue(ev.prettyPrint())
+            self.assertEqual(extn['extnValue'], der_encoder(ev))
+            count += 1
+
+        self.assertEqual(1, count)
+
+    def testOpenTypes(self):
+        ocspResponseMap = opentypemap.get('ocspResponseMap')
+
+        substrate = pem.readBase64fromText(self.ocsp_resp_pem_text)
+        asn1Object, rest = der_decoder(substrate,
+            asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+        self.assertEqual(0, asn1Object['responseStatus'])
+
+        rb = asn1Object['responseBytes']
+        self.assertIn(rb['responseType'], ocspResponseMap)
+
+        resp, rest = der_decoder(rb['response'],
+            asn1Spec=ocspResponseMap[rb['responseType']], decodeOpenTypes=True)
+        self.assertFalse(rest)
+        self.assertTrue(resp.prettyPrint())
+        self.assertEqual(rb['response'], der_encoder(resp))
+        self.assertEqual(0, resp['tbsResponseData']['version'])
+
+        for rdn in resp['tbsResponseData']['responderID']['byName']['rdnSequence']:
+            for attr in rdn:
+                if attr['type'] == rfc5280.id_emailAddress:
+                    self.assertEqual('info@snmplabs.com', attr['value'])
+
+        for r in resp['tbsResponseData']['responses']:
+            ha = r['certID']['hashAlgorithm']
+            self.assertEqual(rfc4055.id_sha1, ha['algorithm'])
+            self.assertEqual(univ.Null(""), ha['parameters'])
+
+
+class BadNonceSizeTestCase(unittest.TestCase):
+    empty_nonce_extn_value_pem_text = "BAA="
+    big_nonce_extn_value_pem_text = """\
+BIGgtY7oVxpr39n/QprRa5bpcQIvbV/g93PpSPiRrhaL6g44WCC4TnY88ZUjS7fE
+LcgfSW5gA/oakaDA2BCsXodVAF+DRoIGZVjPpn50Yf4ODJ3mWp3uyuF51dVILqiX
+XXyGcd+/99CTkvg2eBx1GFM8HmwuP2boVIJPqijeqEH/DQWlJH7D56IVmNcfG6CB
+d1ZMFfmbH+xL0vlSalpnQ2DEKA==
+"""
+
+    def setUp(self):
+        self.asn1Spec = rfc8954.Nonce()
+
+    def testEmptyNonceValueConstraintError(self):
+        substrate = pem.readBase64fromText(self.empty_nonce_extn_value_pem_text)
+        with self.assertRaises(error.ValueConstraintError):
+            ev, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+    def testBigNonceValueConstraintError(self):
+        substrate = pem.readBase64fromText(self.big_nonce_extn_value_pem_text)
+        with self.assertRaises(error.ValueConstraintError):
+            ev, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == '__main__':
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(not result.wasSuccessful())


### PR DESCRIPTION
Add module and test for RFC 8954, which provides the Online Certificate Status Protocol (OCSP) with nonce size constrained to 32 octets.