### PR TITLE
Fix bug in RFC 9480

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,7 @@ Revision 0.4.4, released ??-??-2024
 - Added support for Python 3.12, and dropped support for Python 3.5.
 - Added RFC9548 for Generating Transport Key Containers Using the GOST Algorithms
 - Added RFC8964 for Online Certificate Status Protocol (OCSP) with Nonce constraints
+- Modified RFC9480 (CMP updates) to make InfoTypeAndValue['infoType'] optional
 
 Revision 0.4.3, released 08-02-2024
 -----------------------------------

--- a/pyasn1_alt_modules/rfc9480.py
+++ b/pyasn1_alt_modules/rfc9480.py
@@ -2,8 +2,9 @@
 # This file is part of pyasn1_alt_modules software.
 #
 # Created by Russ Housley with minor assistance from asn1ate v.0.6.0.
+# Modified by Russ Housley to make InfoTypeAndValue['infoType'] optional.
 #
-# Copyright (c) 2021-2024, Vigil Security, LLC
+# Copyright (c) 2021, Vigil Security, LLC
 # License: http://vigilsec.com/pyasn1_alt_modules_license.txt
 #
 # Updates to the Certificate Management Protocol (CMP)
@@ -143,7 +144,7 @@ RevReqContent = rfc4210.RevReqContent
 class InfoTypeAndValue(univ.Sequence):
     componentType = namedtype.NamedTypes(
         namedtype.NamedType('infoType', univ.ObjectIdentifier()),
-        namedtype.NamedType('infoValue', univ.Any(),
+        namedtype.OptionalNamedType('infoValue', univ.Any(),
             openType=opentype.OpenType('infoType', cmpInfoTypeAndValueMap))
     )
 


### PR DESCRIPTION
Make InfoTypeAndValue['infoType'] optional.