### PR TITLE
Address errata for RFC 8708

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ Revision 0.4.5, released XX-XX-2024
 - Added RFC9582 for RPKI Route Origin Authorizations (ROAs)
 - Added RFC9579 for Use of PBMAC1 in the PKCS #12 Syntax
 - Improve RFC9480 by updating the algorithm identifier map and fix typo
+- Improve RFC8708 by addressing errata eid7963, which only changes a comment
 
 Revision 0.4.4, released 03-22-2024
 -----------------------------------

--- a/pyasn1_alt_modules/rfc8708.py
+++ b/pyasn1_alt_modules/rfc8708.py
@@ -9,6 +9,7 @@
 #
 # ASN.1 source from:
 # https://www.rfc-editor.org/rfc/rfc8708.txt
+# https://www.rfc-editor.org/errata/eid7963
 
 
 from pyasn1.type import univ
@@ -38,5 +39,5 @@ class HSS_LMS_HashSig_PublicKey(univ.OctetString):
 
 pk_HSS_LMS_HashSig = rfc5280.SubjectPublicKeyInfo()
 pk_HSS_LMS_HashSig['algorithm'] = sa_HSS_LMS_HashSig
-# pk_HSS_LMS_HashSig['subjectPublicKey'] CONTAINS a
-#     DER-encoded HSS_LMS_HashSig_PublicKey
+# pk_HSS_LMS_HashSig['subjectPublicKey'] CONTAINS the
+#     HSS/LMS public key without any ASN.1 encoding


### PR DESCRIPTION
Improve RFC8708 by addressing errata eid7963, which only changes a comment.