### PR TITLE
Drop support for EOL Python 2.7, 3.6, and 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: python
 cache: pip
 matrix:
   include:
-  - python: '2.7'
-  - python: '3.5'
-  - python: '3.6'
-  - python: '3.7'
   - python: '3.8'
+  - python: '3.9'
+  - python: '3.10'
+  - python: '3.11'
+  - python: '3.12'
   - python: 'nightly'
   - python: 'pypy'
   - python: 'pypy3'

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
-Revision 0.4.5, released XX-XX-2024
+Revision 0.4.5, released 28-08-2024
 -----------------------------------
+- Dropped support for EOL Python 2.7, 3.6, and 3.7
 - Added RFC9598 for Internationalized Email Addresses in X.509 Certificates
 - Added RFC9582 for RPKI Route Origin Authorizations (ROAs)
 - Added RFC9579 for Use of PBMAC1 in the PKCS #12 Syntax

--- a/setup.py
+++ b/setup.py
@@ -31,38 +31,26 @@ Intended Audience :: Telecommunications Industry
 License :: OSI Approved :: BSD License
 Natural Language :: English
 Operating System :: OS Independent
-Programming Language :: Python :: 2
-Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.6
-Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
 Programming Language :: Python :: 3.11
 Programming Language :: Python :: 3.12
 Topic :: Communications
-Topic :: System :: Monitoring
-Topic :: System :: Networking :: Monitoring
 Topic :: Software Development :: Libraries :: Python Modules
 """
-
 
 def howto_install_setuptools():
     print("""
    Error: You need setuptools Python package!
 
-   It's very easy to install it, just type (as root on Linux):
-
-   wget https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py
-   python ez_setup.py
-
-   Then you could make eggs from this package.
+   It's very easy to install it; see https://pypi.org/project/ez_setup/.
 """)
 
 
-if sys.version_info[:2] < (2, 7):
-    print("ERROR: this package requires Python 2.7 or later!")
+if sys.version_info[:2] < (3, 8):
+    print("ERROR: this package requires Python 3.8 or later!")
     sys.exit(1)
 
 try:
@@ -99,7 +87,7 @@ params.update(
      'classifiers': [x for x in classifiers.split('\n') if x],
      'license': 'BSD-2-Clause',
      'packages': ['pyasn1_alt_modules'],
-     'python_requires': '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*'})
+     'python_requires': '>=3.8'})
 
 class PyTest(Command):
     user_options = []

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.4.0
 envlist =
-    {py27, py35, py36, py37, py38}-{unittest},
+    {py38, py39, py310, py311, py312}-{unittest},
     cover, docs, bandit, build
 isolated_build = true
 skip_missing_interpreters = true
@@ -22,18 +22,6 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     discover -s examples/pyasn1_alt_modules-example-switch/tests -s tests
-
-[testenv:py27-unittest]
-deps = {[testenv:unittest]deps}
-commands = {[testenv:unittest]commands}
-
-[testenv:py36-unittest]
-deps = {[testenv:unittest]deps}
-commands = {[testenv:unittest]commands}
-
-[testenv:py37-unittest]
-deps = {[testenv:unittest]deps}
-commands = {[testenv:unittest]commands}
 
 [testenv:py38-unittest]
 deps = {[testenv:unittest]deps}


### PR DESCRIPTION
Release 0.4.5.  The pyasn1 library no longer supports Python 2.7, 3.6, and 3.7, so they are dropped here too.