### PR TITLE
Add support for RFC 5794

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,8 @@ Revision 0.4.7, released DD-MMM-2025
 - Cleanup setup.cfg and setup.py
 - Added RFC9763 for Related Certificates for Use in Multiple Authentications
   within a Protocol
+- Add RFC5794 providing the ARIA Encryption Algorithm, which is possible
+  since pyasn1 0.6.0 and later includes support for univ.RelativeOID
 
 Revision 0.4.6, released 25-MAR-2025
 ------------------------------------

--- a/pyasn1_alt_modules/rfc5794.py
+++ b/pyasn1_alt_modules/rfc5794.py
@@ -1,0 +1,395 @@
+#
+# This file is part of pyasn1-alt-modules software.
+#
+# Created by Russ Housley.
+# Modified by Russ Housley to use opentypemap.
+#
+# Copyright (c) 2020-2025, Vigil Security, LLC
+# License: http://vigilsec.com/pyasn1-alt-modules-license.txt
+#
+# The ARIA Encryption Algorithm
+#
+# ASN.1 source from:
+# https://www.rfc-editor.org/rfc/rfc5794.txt
+# https://www.rfc-editor.org/errata/eid2064
+#
+
+from pyasn1.type import constraint
+from pyasn1.type import namedtype
+from pyasn1.type import univ
+
+from pyasn1_alt_modules import rfc5280
+from pyasn1_alt_modules import opentypemap
+
+
+algorithmIdentifierMap = opentypemap.get('algorithmIdentifierMap')
+
+
+# Import from RFC 5280
+
+AlgorithmIdentifier = rfc5280.AlgorithmIdentifier
+
+
+# Object Identifiers
+
+OID = univ.ObjectIdentifier
+
+
+id_algorithm = univ.ObjectIdentifier((1, 2, 410, 200046, 1,))
+
+id_sea = id_algorithm + (1,)
+
+id_pad = id_algorithm + (2,)
+
+
+id_aria128_ecb = id_sea + (1,)
+
+id_aria128_cbc = id_sea + (2,)
+
+id_aria128_cfb = id_sea + (3,)
+
+id_aria128_ofb = id_sea + (4,)
+
+id_aria128_ctr = id_sea + (5,)
+
+id_aria192_ecb = id_sea + (6,)
+
+id_aria192_cbc = id_sea + (7,)
+
+id_aria192_cfb = id_sea + (8,)
+
+id_aria192_ofb = id_sea + (9,)
+
+id_aria192_ctr = id_sea + (10,)
+
+id_aria256_ecb = id_sea + (11,)
+
+id_aria256_cbc = id_sea + (12,)
+
+id_aria256_cfb = id_sea + (13,)
+
+id_aria256_ofb = id_sea + (14,)
+
+id_aria256_ctr = id_sea + (15,)
+
+id_aria128_cmac = id_sea + (21,)
+
+id_aria192_cmac = id_sea + (22,)
+
+id_aria256_cmac = id_sea + (23,)
+
+id_aria128_ocb2 = id_sea + (31,)
+
+id_aria192_ocb2 = id_sea + (32,)
+
+id_aria256_ocb2 = id_sea + (33,)
+
+id_aria128_gcm = id_sea + (34,)
+
+id_aria192_gcm = id_sea + (35,)
+
+id_aria256_gcm = id_sea + (36,)
+
+id_aria128_ccm = id_sea + (37,)
+
+id_aria192_ccm = id_sea + (38,)
+
+id_aria256_ccm = id_sea + (39,)
+
+id_aria128_kw = id_sea + (40,)
+
+id_aria192_kw = id_sea + (41,)
+
+id_aria256_kw = id_sea + (42,)
+
+id_aria128_kwp = id_sea + (43,)
+
+id_aria192_kwp = id_sea + (44,)
+
+id_aria256_kwp = id_sea + (45,)
+
+
+# Relative OIDs
+
+id_pad_null = univ.RelativeOID('0') # no padding algorithms identified
+
+id_pad_1 = univ.RelativeOID('1')    # padding method 2 of ISO/IEC 9797-1:1999
+
+
+# Parameters
+
+class AriaPadAlgo(univ.Choice):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('specifiedPadAlgo', univ.RelativeOID()),
+        namedtype.NamedType('generalPadAlgo', univ.ObjectIdentifier())
+    )
+
+
+default_aria_pad_algo_null = AriaPadAlgo()
+default_aria_pad_algo_null['specifiedPadAlgo'] = id_pad_null
+
+
+default_aria_pad_algo_1 = AriaPadAlgo()
+default_aria_pad_algo_1['specifiedPadAlgo'] = id_pad_1
+
+
+class AriaEcbParameters(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.DefaultedNamedType('padAlgo', default_aria_pad_algo_null)
+    )
+
+
+class AriaCbcParameters(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.DefaultedNamedType('m', univ.Integer().subtype(value=1)),
+        namedtype.DefaultedNamedType('padAlgo', default_aria_pad_algo_1)
+    )
+
+
+class AriaCfbParameters(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('r', univ.Integer()),  #  128<=r<=128*1024
+        namedtype.NamedType('k', univ.Integer()),  #  1<=k<=128
+        namedtype.NamedType('j', univ.Integer()),  #  1<=j<=k
+        namedtype.DefaultedNamedType('padAlgo', default_aria_pad_algo_null)
+    )
+
+
+class AriaOfbParameters(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('j', univ.Integer()),  #  1<=j<=128
+        namedtype.DefaultedNamedType('padAlgo', default_aria_pad_algo_null)
+    )
+
+
+class AriaCtrParameters(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('j', univ.Integer()),  #  1<=j<=128
+        namedtype.DefaultedNamedType('padAlgo', default_aria_pad_algo_null)
+    )
+
+
+class AriaCmacParameters(univ.Integer):
+    pass
+
+
+class AriaOcb2Parameters(univ.Integer):
+    pass
+
+
+class AriaGcmParameters(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('s', univ.Integer()),
+        namedtype.NamedType('t', univ.Integer())
+    )
+
+
+class AriaCcmParameters(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('w', univ.Integer().subtype(
+            subtypeSpec=constraint.SingleValueConstraint(
+                2, 3, 4, 5, 6, 7, 8))),
+        namedtype.NamedType('t', univ.Integer().subtype(
+            subtypeSpec=constraint.SingleValueConstraint(
+                32, 48, 64, 80, 96, 112, 128)))
+    )
+
+
+# Algorithm Identifiers
+
+class AriaModeOfOperation(AlgorithmIdentifier):
+    pass
+
+
+aria128ecb = AlgorithmIdentifier()
+aria128ecb['algorithm'] = id_aria128_ecb
+aria128ecb['parameters'] = AriaEcbParameters() 
+
+
+aria128cbc = AlgorithmIdentifier()
+aria128cbc['algorithm'] = id_aria128_cbc
+aria128cbc['parameters'] = AriaCbcParameters() 
+
+
+aria128cfb = AlgorithmIdentifier()
+aria128cfb['algorithm'] = id_aria128_cfb
+aria128cfb['parameters'] = AriaCfbParameters() 
+
+
+aria128ofb = AlgorithmIdentifier()
+aria128ofb['algorithm'] = id_aria128_ofb
+aria128ofb['parameters'] = AriaOfbParameters() 
+
+
+aria128ctr = AlgorithmIdentifier()
+aria128ctr['algorithm'] = id_aria128_ctr
+aria128ctr['parameters'] = AriaCtrParameters() 
+
+
+aria192ecb = AlgorithmIdentifier()
+aria192ecb['algorithm'] = id_aria192_ecb
+aria192ecb['parameters'] = AriaEcbParameters() 
+
+
+aria192cbc = AlgorithmIdentifier()
+aria192cbc['algorithm'] = id_aria192_cbc
+aria192cbc['parameters'] = AriaCbcParameters() 
+
+
+aria192cfb = AlgorithmIdentifier()
+aria192cfb['algorithm'] = id_aria192_cfb
+aria192cfb['parameters'] = AriaCfbParameters() 
+
+
+aria192ofb = AlgorithmIdentifier()
+aria192ofb['algorithm'] = id_aria192_ofb
+aria192ofb['parameters'] = AriaOfbParameters() 
+
+
+aria192ctr = AlgorithmIdentifier()
+aria192ctr['algorithm'] = id_aria192_ctr
+aria192ctr['parameters'] = AriaCtrParameters() 
+
+
+aria256ecb = AlgorithmIdentifier()
+aria256ecb['algorithm'] = id_aria256_ecb
+aria256ecb['parameters'] = AriaEcbParameters() 
+
+
+aria256cbc = AlgorithmIdentifier()
+aria256cbc['algorithm'] = id_aria256_cbc
+aria256cbc['parameters'] = AriaCbcParameters() 
+
+
+aria256cfb = AlgorithmIdentifier()
+aria256cfb['algorithm'] = id_aria256_cfb
+aria256cfb['parameters'] = AriaCfbParameters() 
+
+
+aria256ofb = AlgorithmIdentifier()
+aria256ofb['algorithm'] = id_aria256_ofb
+aria256ofb['parameters'] = AriaOfbParameters() 
+
+
+aria256ctr = AlgorithmIdentifier()
+aria256ctr['algorithm'] = id_aria256_ctr
+aria256ctr['parameters'] = AriaCtrParameters() 
+
+
+aria128cmac = AlgorithmIdentifier()
+aria128cmac['algorithm'] = id_aria128_cmac
+aria128cmac['parameters'] = AriaCmacParameters() 
+
+
+aria192cmac = AlgorithmIdentifier()
+aria192cmac['algorithm'] = id_aria192_cmac
+aria192cmac['parameters'] = AriaCmacParameters() 
+
+
+aria256cmac = AlgorithmIdentifier()
+aria256cmac['algorithm'] = id_aria256_cmac
+aria256cmac['parameters'] = AriaCmacParameters() 
+
+
+aria128ocb2 = AlgorithmIdentifier()
+aria128ocb2['algorithm'] = id_aria128_ocb2
+aria128ocb2['parameters'] = AriaOcb2Parameters() 
+
+
+aria192ocb2 = AlgorithmIdentifier()
+aria192ocb2['algorithm'] = id_aria192_ocb2
+aria192ocb2['parameters'] = AriaOcb2Parameters() 
+
+
+aria256ocb2 = AlgorithmIdentifier()
+aria256ocb2['algorithm'] = id_aria256_ocb2
+aria256ocb2['parameters'] = AriaOcb2Parameters() 
+
+
+aria128gcm = AlgorithmIdentifier()
+aria128gcm['algorithm'] = id_aria128_gcm
+aria128gcm['parameters'] = AriaGcmParameters() 
+
+
+aria192gcm = AlgorithmIdentifier()
+aria192gcm['algorithm'] = id_aria192_gcm
+aria192gcm['parameters'] = AriaGcmParameters() 
+
+
+aria256gcm = AlgorithmIdentifier()
+aria256gcm['algorithm'] = id_aria256_gcm
+aria256gcm['parameters'] = AriaGcmParameters() 
+
+
+aria128ccm = AlgorithmIdentifier()
+aria128ccm['algorithm'] = id_aria128_ccm
+aria128ccm['parameters'] = AriaCcmParameters() 
+
+
+aria192ccm = AlgorithmIdentifier()
+aria192ccm['algorithm'] = id_aria192_ccm
+aria192ccm['parameters'] = AriaCcmParameters() 
+
+
+aria256ccm = AlgorithmIdentifier()
+aria256ccm['algorithm'] = id_aria256_ccm
+aria256ccm['parameters'] = AriaCcmParameters() 
+
+
+aria128kw = AlgorithmIdentifier()
+aria128kw['algorithm'] = id_aria128_kw
+
+
+aria192kw = AlgorithmIdentifier()
+aria192kw['algorithm'] = id_aria192_kw
+
+
+aria256kw = AlgorithmIdentifier()
+aria256kw['algorithm'] = id_aria256_kw
+
+
+aria128kwp = AlgorithmIdentifier()
+aria128kwp['algorithm'] = id_aria128_kwp
+
+
+aria192kwp = AlgorithmIdentifier()
+aria192kwp['algorithm'] = id_aria192_kwp
+
+
+aria256kwp = AlgorithmIdentifier()
+aria256kwp['algorithm'] = id_aria256_kwp
+
+
+# Update the Algorithm Identifier map
+
+_algorithmIdentifierMapUpdate = {
+    id_aria128_ecb: AriaEcbParameters(),
+    id_aria128_cbc: AriaCbcParameters(),
+    id_aria128_cfb: AriaCfbParameters(),
+    id_aria128_ofb: AriaOfbParameters(),
+    id_aria128_ctr: AriaCtrParameters(),
+    id_aria192_ecb: AriaEcbParameters(),
+    id_aria192_cbc: AriaCbcParameters(),
+    id_aria192_cfb: AriaCfbParameters(),
+    id_aria192_ofb: AriaOfbParameters(),
+    id_aria192_ctr: AriaCtrParameters(),
+    id_aria256_ecb: AriaEcbParameters(),
+    id_aria256_cbc: AriaCbcParameters(),
+    id_aria256_cfb: AriaCfbParameters(),
+    id_aria256_ofb: AriaOfbParameters(),
+    id_aria256_ctr: AriaCtrParameters(),
+    id_aria128_cmac: AriaCmacParameters(),
+    id_aria192_cmac: AriaCmacParameters(),
+    id_aria256_cmac: AriaCmacParameters(),
+    id_aria128_ocb2: AriaOcb2Parameters(),
+    id_aria192_ocb2: AriaOcb2Parameters(),
+    id_aria256_ocb2: AriaOcb2Parameters(),
+    id_aria128_gcm: AriaGcmParameters(),
+    id_aria192_gcm: AriaGcmParameters(),
+    id_aria256_gcm: AriaGcmParameters(),
+    id_aria128_ccm: AriaCcmParameters(),
+    id_aria192_ccm: AriaCcmParameters(),
+    id_aria256_ccm: AriaCcmParameters(),
+}
+
+algorithmIdentifierMap.update(_algorithmIdentifierMapUpdate)

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -89,6 +89,7 @@ suite = unittest.TestLoader().loadTestsFromNames(
      'tests.test_rfc5752.suite',
      'tests.test_rfc5753.suite',
      'tests.test_rfc5755.suite',
+     'tests.test_rfc5794.suite',
      'tests.test_rfc5913.suite',
      'tests.test_rfc5914.suite',
      'tests.test_rfc5915.suite',

--- a/tests/test_rfc5794.py
+++ b/tests/test_rfc5794.py
@@ -1,0 +1,258 @@
+#
+# This file is part of pyasn1-alt-modules software.
+#
+# Created by Russ Housley
+# Copyright (c) 2020-2025, Vigil Security, LLC
+# License: http://vigilsec.com/pyasn1-alt-modules-license.txt
+#
+import sys
+import platform
+import unittest
+
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
+
+from pyasn1.type import univ
+
+from pyasn1_alt_modules import pem
+from pyasn1_alt_modules import rfc5280
+from pyasn1_alt_modules import rfc5652
+from pyasn1_alt_modules import rfc5751
+from pyasn1_alt_modules import rfc5794
+from pyasn1_alt_modules import opentypemap
+
+
+class SMIMECapabilitiesTestCase(unittest.TestCase):
+    pem_text = """\
+MIGtMBAGCSqDGoyabgEBATADDQEBMBkGCSqDGoyabgEBAjAMBgorBgEEAYGsYDBP
+MBcGCSqDGoyabgEBAzAKAgIAgAIBQAIBIDAQBgkqgxqMmm4BAQQwAwIBIDAOBgkq
+gxqMmm4BARUCAWAwFAYJKoMajJpuAQEiMAcCAgCAAgFgMBMGCSqDGoyabgEBJTAG
+AgEIAgFgMAsGCSqDGoyabgEBKDALBgkqgxqMmm4BASs=
+"""
+
+    def setUp(self):
+        self.asn1Spec = rfc5751.SMIMECapabilities()
+
+    def testDerCodec(self):
+        algorithmIdentifierMap = opentypemap.get('algorithmIdentifierMap')
+
+        substrate = pem.readBase64fromText(self.pem_text)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        alg_oid_list = [ ]
+        for cap in asn1Object:
+            alg_oid_list.append(cap['capabilityID'])
+            if cap['parameters'].hasValue():
+                self.assertIn(cap['capabilityID'], algorithmIdentifierMap)
+                param, rest = der_decoder(cap['parameters'],
+                    asn1Spec=algorithmIdentifierMap[cap['capabilityID']])
+                self.assertFalse(rest)
+                self.assertTrue(param.prettyPrint())
+                self.assertEqual(cap['parameters'], der_encoder(param))
+
+        self.assertEqual(9, len(alg_oid_list))
+
+    def testOpenTypes(self):
+        algorithmIdentifierMap = opentypemap.get('algorithmIdentifierMap')
+
+        substrate = pem.readBase64fromText(self.pem_text)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec,
+            openTypes=algorithmIdentifierMap, decodeOpenTypes=True)
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        count = 0
+        for cap in asn1Object:
+            count += 1
+            capOID = cap['capabilityID']
+            if cap['parameters'].hasValue():
+                self.assertIn(cap['capabilityID'], algorithmIdentifierMap)
+                if cap['capabilityID'] == rfc5794.id_aria128_ecb:       
+                    self.assertEqual(rfc5794.id_pad_1, cap['parameters']['padAlgo'][0])
+
+        self.assertEqual(9, count)
+
+
+class EncryptedDataBogusPadTestCase(unittest.TestCase):
+    pem_text = """\
+MIIFkAYJKoZIhvcNAQcDoIIFgTCCBX0CAQIxWqJYAgEEMCQEEDiCUYXKXu8SzLos
+n2xeYP4YEDIwMjAwOTEwODEyMDAwMFowCwYJKoMajJpuAQEqBCCh8LBZuLKwVns7
+LxY59rh49JIEq25KH5GnMblbSVUanTCCBRoGCSqGSIb3DQEHATAZBgkqgxqMmm4B
+AQIwDAYKKwYBBAGBrGAwT4CCBPBGQUtFX0lWX0ZBS0VfSVYhc8exehjJD/gtEOIr
+g6tK5Emaa4PJ7l8f+EtyDD/ffQayXVAGz2MXUIQMEzmSLrnsr9NEyXvxGpvcsi7m
+V8tDxZU0YuyhA/C/HMh7EaBKG1hjC7xNw+IRIUxrbRJakMQbzMWWYJupC5zRu4/G
+e9i+JVOGgES2E0L5LZSZ53wmnHA0ols1PHl3F3Z2QM3CkewqA3NP1waXQ0XXb0Oy
+l6Gq12B7ksm7euPWA3KctEjfYBD6nBT6wQd57rAMeFTk5aceWd2Sb/0xMpjfCg6G
+zX8pAWVEU8LqTvVmlSWdx3f3fAtUgiZ+gx7jNY8A6duln8zvMQn3mtPDCa50GzSr
+Ax8JreHRWSDr3Dp8EfJzUgfy7dWlI9xs5bh1TMkEMk+AHWQ5sBXTZkDgVAS5m1mI
+bXe7dzuxKsfGxjWu1eyy9J77mtOGo9aAOqYfxv/I8YQcgWHTeQcIO39Rmt2QsI7t
+rRaEJ1jgj2E1To5gRCbIQWzQuyoS6affgu/9dwPXCAt0+0XrnO5vhaKX/RWm7ve8
+hYsiT0vI0hdBJ3rDRkdS9VL6NlnXOuohAqEq8b3s2koBigdri052hceAElTHD+4A
+4qRDiMLlFLlQqoJlpBwCtEPZsIQSy62K7J/Towxxab5FoFjUTC5f79xPQPoKxYdg
+UB5AeAu5HgdWTn49Uqg4v/spTPSNRTmDMVVyZ9qhzJfkDpH3TKCAE5t59w4gSPe/
+7l+MeSml9O+L9HTd9Vng3LBbIds3uQ4cfLyyQmly81qpJjR1+Rvwo46hOm0kf2sI
+Fi0WULmP/XzLw6b1SbiHf/jqFg7TFTyLMkPMPMmc7/kpLmYbKyTB4ineasTUL+bD
+rwu+uSzFAjTcI+1sz4Wo4p7RVywBDKSI5Ocbd3iMt4XWJWtz0KBX6nBzlV+BBTCw
+aGMAU4IpPBYOuvcl7TJWx/ODBjbO4zm4T/66w5IG3tKpsVMs4Jtrh8mtVXCLTBmK
+DzyjBVN2X8ALGXarItRgLa7k80lJjqTHwKCjiAMmT/eh67KzwmqBq5+8rJuXkax0
+NoXcDu6xkCMNHUQBYdnskaJqC2pu8hIsPTOrh7ieYSEuchFvu7lI0E+p7ypW65CM
+iy+Y/Rm5OWeHzjKkU5AbPtx/Me2vpQRCgaPwciZunx2Ivi1+WYUBU1pGNDO7Xz7a
+8UHbDURkh7b+40uz2d7YQjKgrZBv6YwLAmw1LTE4bT9PM9n7LROnX8u6ksei8yiw
+8gZeVu+plWHbF+0O9siKAgxZlBna0XFgPpdzjMDTS/sfTIYXWlFj7camhsmTDRjo
+5G2B212evaKmKgh5ALLSFSk86ZN5KvQvcfsp81jvJCBmDStrsUgSMzy0Og2quHOd
+61hRTVlYzwvJvfMzHGKdIWwYUbHZOKo/KLEk3E36U9PkPoZGEL2ZeCH4F9Wh3mgg
+0knBfEmlPnGexmBby6NXGK7VW3l6xcJlpdMaXKNVMfl2YK8k/34Hyft06KaYLEJs
+xAqk1pmLEmGhdZC1OAqovVB/1agSzpMMaB9OWWqNsTjDc7tkDt8BZ72NsAbCI9Xm
+sX81W+NqPb6Ju1dtI09bn113LX/ZbOSdVicQcXSpl0FnTZaHgHJdQLcU28O7yFFO
+blqrvcMKpctdTA1TwG9LXEFttGrlpgjZF3edo0Cez10epK+S
+"""
+
+    def setUp(self):
+        self.asn1Spec = rfc5652.ContentInfo()
+
+    def testDerCodec(self):
+        substrate = pem.readBase64fromText(self.pem_text)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+        self.assertEqual(rfc5652.id_envelopedData, asn1Object['contentType'])
+
+        ed, rest = der_decoder(asn1Object['content'],
+            asn1Spec=rfc5652.EnvelopedData())
+        self.assertFalse(rest)
+        self.assertTrue(ed.prettyPrint())
+        self.assertEqual(asn1Object['content'], der_encoder(ed))
+
+        kwa = ed['recipientInfos'][0]['kekri']['keyEncryptionAlgorithm']
+        self.assertEqual(rfc5794.id_aria256_kw, kwa['algorithm'])
+
+        cea = ed['encryptedContentInfo']['contentEncryptionAlgorithm']
+        self.assertEqual(rfc5794.id_aria128_cbc, cea['algorithm'])
+
+        param, rest = der_decoder(cea['parameters'],
+            asn1Spec=rfc5794.AriaCbcParameters())
+        self.assertFalse(rest)
+        self.assertTrue(param.prettyPrint())
+        self.assertEqual(cea['parameters'], der_encoder(param))
+
+        id_bogus_pad_alg = univ.ObjectIdentifier('1.3.6.1.4.1.22112.48.79')
+        self.assertEqual(id_bogus_pad_alg, param['padAlgo']['generalPadAlgo'])
+
+    def testOpenTypes(self):
+        substrate = pem.readBase64fromText(self.pem_text)
+        asn1Object, rest = der_decoder(substrate,
+            asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        kekri = asn1Object['content']['recipientInfos'][0]['kekri']
+        kwa = kekri['keyEncryptionAlgorithm']
+        self.assertEqual(rfc5794.id_aria256_kw, kwa['algorithm'])
+
+        eci = asn1Object['content']['encryptedContentInfo']
+        cea = eci['contentEncryptionAlgorithm']
+        self.assertEqual(rfc5794.id_aria128_cbc, cea['algorithm'])
+
+        id_bogus_pad_alg = univ.ObjectIdentifier('1.3.6.1.4.1.22112.48.79')
+        gpa = cea['parameters']['padAlgo']['generalPadAlgo']
+        self.assertEqual(id_bogus_pad_alg, gpa)
+
+
+class EncryptedDataDefaultPadTestCase(unittest.TestCase):
+    pem_text = """\
+MIIFhAYJKoZIhvcNAQcDoIIFdTCCBXECAQIxWqJYAgEEMCQEEDiCUYXKXu8SzLos
+n2xeYP4YEDIwMjAwOTEwODEyMDAwMFowCwYJKoMajJpuAQEqBCCh8LBZuLKwVns7
+LxY59rh49JIEq25KH5GnMblbSVUanTCCBQ4GCSqGSIb3DQEHATANBgkqgxqMmm4B
+AQIwAICCBPBGQUtFX0lWX0ZBS0VfSVYhc8exehjJD/gtEOIrg6tK5Emaa4PJ7l8f
++EtyDD/ffQayXVAGz2MXUIQMEzmSLrnsr9NEyXvxGpvcsi7mV8tDxZU0YuyhA/C/
+HMh7EaBKG1hjC7xNw+IRIUxrbRJakMQbzMWWYJupC5zRu4/Ge9i+JVOGgES2E0L5
+LZSZ53wmnHA0ols1PHl3F3Z2QM3CkewqA3NP1waXQ0XXb0Oyl6Gq12B7ksm7euPW
+A3KctEjfYBD6nBT6wQd57rAMeFTk5aceWd2Sb/0xMpjfCg6GzX8pAWVEU8LqTvVm
+lSWdx3f3fAtUgiZ+gx7jNY8A6duln8zvMQn3mtPDCa50GzSrAx8JreHRWSDr3Dp8
+EfJzUgfy7dWlI9xs5bh1TMkEMk+AHWQ5sBXTZkDgVAS5m1mIbXe7dzuxKsfGxjWu
+1eyy9J77mtOGo9aAOqYfxv/I8YQcgWHTeQcIO39Rmt2QsI7trRaEJ1jgj2E1To5g
+RCbIQWzQuyoS6affgu/9dwPXCAt0+0XrnO5vhaKX/RWm7ve8hYsiT0vI0hdBJ3rD
+RkdS9VL6NlnXOuohAqEq8b3s2koBigdri052hceAElTHD+4A4qRDiMLlFLlQqoJl
+pBwCtEPZsIQSy62K7J/Towxxab5FoFjUTC5f79xPQPoKxYdgUB5AeAu5HgdWTn49
+Uqg4v/spTPSNRTmDMVVyZ9qhzJfkDpH3TKCAE5t59w4gSPe/7l+MeSml9O+L9HTd
+9Vng3LBbIds3uQ4cfLyyQmly81qpJjR1+Rvwo46hOm0kf2sIFi0WULmP/XzLw6b1
+SbiHf/jqFg7TFTyLMkPMPMmc7/kpLmYbKyTB4ineasTUL+bDrwu+uSzFAjTcI+1s
+z4Wo4p7RVywBDKSI5Ocbd3iMt4XWJWtz0KBX6nBzlV+BBTCwaGMAU4IpPBYOuvcl
+7TJWx/ODBjbO4zm4T/66w5IG3tKpsVMs4Jtrh8mtVXCLTBmKDzyjBVN2X8ALGXar
+ItRgLa7k80lJjqTHwKCjiAMmT/eh67KzwmqBq5+8rJuXkax0NoXcDu6xkCMNHUQB
+YdnskaJqC2pu8hIsPTOrh7ieYSEuchFvu7lI0E+p7ypW65CMiy+Y/Rm5OWeHzjKk
+U5AbPtx/Me2vpQRCgaPwciZunx2Ivi1+WYUBU1pGNDO7Xz7a8UHbDURkh7b+40uz
+2d7YQjKgrZBv6YwLAmw1LTE4bT9PM9n7LROnX8u6ksei8yiw8gZeVu+plWHbF+0O
+9siKAgxZlBna0XFgPpdzjMDTS/sfTIYXWlFj7camhsmTDRjo5G2B212evaKmKgh5
+ALLSFSk86ZN5KvQvcfsp81jvJCBmDStrsUgSMzy0Og2quHOd61hRTVlYzwvJvfMz
+HGKdIWwYUbHZOKo/KLEk3E36U9PkPoZGEL2ZeCH4F9Wh3mgg0knBfEmlPnGexmBb
+y6NXGK7VW3l6xcJlpdMaXKNVMfl2YK8k/34Hyft06KaYLEJsxAqk1pmLEmGhdZC1
+OAqovVB/1agSzpMMaB9OWWqNsTjDc7tkDt8BZ72NsAbCI9XmsX81W+NqPb6Ju1dt
+I09bn113LX/ZbOSdVicQcXSpl0FnTZaHgHJdQLcU28O7yFFOblqrvcMKpctdTA1T
+wG9LXEFttGrlpgjZF3edo0Cez10epK+S
+"""
+
+    def setUp(self):
+        self.asn1Spec = rfc5652.ContentInfo()
+
+    def testDerCodec(self):
+        substrate = pem.readBase64fromText(self.pem_text)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+        self.assertEqual(rfc5652.id_envelopedData, asn1Object['contentType'])
+
+        ed, rest = der_decoder(asn1Object['content'],
+            asn1Spec=rfc5652.EnvelopedData())
+        self.assertFalse(rest)
+        self.assertTrue(ed.prettyPrint())
+        self.assertEqual(asn1Object['content'], der_encoder(ed))
+
+        kwa = ed['recipientInfos'][0]['kekri']['keyEncryptionAlgorithm']
+        self.assertEqual(rfc5794.id_aria256_kw, kwa['algorithm'])
+
+        cea = ed['encryptedContentInfo']['contentEncryptionAlgorithm']
+        self.assertEqual(rfc5794.id_aria128_cbc, cea['algorithm'])
+
+        param, rest = der_decoder(cea['parameters'],
+            asn1Spec=rfc5794.AriaCbcParameters())
+        self.assertFalse(rest)
+        self.assertTrue(param.prettyPrint())
+        self.assertEqual(cea['parameters'], der_encoder(param))
+
+        self.assertEqual(1, param['m'])
+        spa = param['padAlgo']['specifiedPadAlgo']
+        self.assertEqual(rfc5794.id_pad_1, spa)
+
+    def testOpenTypes(self):
+        substrate = pem.readBase64fromText(self.pem_text)
+        asn1Object, rest = der_decoder(substrate,
+            asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        # self.assertEqual(substrate, der_encoder(asn1Object))
+
+        kekri = asn1Object['content']['recipientInfos'][0]['kekri']
+        kwa = kekri['keyEncryptionAlgorithm']
+        self.assertEqual(rfc5794.id_aria256_kw, kwa['algorithm'])
+
+        eci = asn1Object['content']['encryptedContentInfo']
+        cea = eci['contentEncryptionAlgorithm']
+        self.assertEqual(rfc5794.id_aria128_cbc, cea['algorithm'])
+        self.assertEqual(1, cea['parameters']['m'])
+        spa = cea['parameters']['padAlgo']['specifiedPadAlgo']
+        self.assertEqual(rfc5794.id_pad_1, spa)
+
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == '__main__':
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(not result.wasSuccessful())


### PR DESCRIPTION
Add RFC5794 providing the ARIA Encryption Algorithm, which is possible since pyasn1 0.6.0 and later includes support for univ.RelativeOID