### PR TITLE
Fix(CMP): Fix CertStatus Component Order

### DIFF
--- a/pyasn1_alt_modules/rfc9480.py
+++ b/pyasn1_alt_modules/rfc9480.py
@@ -283,12 +283,12 @@ class PollRepContent(univ.SequenceOf):
 
 class CertStatus(univ.Sequence):
     componentType = namedtype.NamedTypes(
+        namedtype.NamedType('certHash', univ.OctetString()),
+        namedtype.NamedType('certReqId', univ.Integer()),
+        namedtype.OptionalNamedType('statusInfo', PKIStatusInfo()),
         namedtype.OptionalNamedType('hashAlg',
                                     AlgorithmIdentifier().subtype(explicitTag=tag.Tag(
                                         tag.tagClassContext, tag.tagFormatSimple, 0))),
-        namedtype.NamedType('certHash', univ.OctetString()),
-        namedtype.NamedType('certReqId', univ.Integer()),
-        namedtype.OptionalNamedType('statusInfo', PKIStatusInfo())
     )
 
 

--- a/pyasn1_alt_modules/rfc9810.py
+++ b/pyasn1_alt_modules/rfc9810.py
@@ -302,12 +302,12 @@ class PollRepContent(univ.SequenceOf):
 
 class CertStatus(univ.Sequence):
     componentType = namedtype.NamedTypes(
+        namedtype.NamedType('certHash', univ.OctetString()),
+        namedtype.NamedType('certReqId', univ.Integer()),
+        namedtype.OptionalNamedType('statusInfo', PKIStatusInfo()),
         namedtype.OptionalNamedType('hashAlg',
                                     AlgorithmIdentifier().subtype(explicitTag=tag.Tag(
                                         tag.tagClassContext, tag.tagFormatSimple, 0))),
-        namedtype.NamedType('certHash', univ.OctetString()),
-        namedtype.NamedType('certReqId', univ.Integer()),
-        namedtype.OptionalNamedType('statusInfo', PKIStatusInfo())
     )
 
 


### PR DESCRIPTION
Updates the definition of the `CertStatus` ASN.1 sequence in both `rfc9480.py` and `rfc9810.py` to match the correct field order as specified in their respective RFCs. 


ASN.1 structure corrections:

* Reordered the fields in the `CertStatus` sequence so that `certHash`, `certReqId`, and the optional `statusInfo` come before the optional `hashAlg` field in both `pyasn1_alt_modules/rfc9480.py` and `pyasn1_alt_modules/rfc9810.py`.
* Fix en- and decoding issues, via other backends (e.g., OpenSSL)